### PR TITLE
Pin bulma-phlex gem to main branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,13 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in bulma-phlex-rails.gemspec
 gemspec
 
-gem "irb"
-gem "rake", "~> 13.0"
+group :development, :test do
+  gem "irb"
+  gem "minitest", "~> 5.16"
+  gem "minitest-difftastic"
+  gem "rake", "~> 13.0"
+  gem "rubocop", "~> 1.21"
 
-gem "minitest", "~> 5.16"
-
-gem "rubocop", "~> 1.21"
-
-gem "bulma-phlex", github: "rocksolt/bulma-phlex", branch: "bulma-phlex-rails-prep"
+  # point to main branch of bulma-phlex until it releases related changes in new version
+  gem "bulma-phlex", github: "rocksolt/bulma-phlex", branch: "main"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/rocksolt/bulma-phlex.git
-  revision: 52186441f92a73883326d6895fb33d937a00fc38
-  branch: bulma-phlex-rails-prep
+  revision: 2d66371f418e4720ea5146a7ead89bcaf3d79e99
+  branch: main
   specs:
     bulma-phlex (0.7.0)
       phlex (>= 2.0.2)
@@ -10,36 +10,140 @@ PATH
   remote: .
   specs:
     bulma-phlex-rails (0.1.0)
+      actionpack (>= 7.2)
+      phlex-rails (>= 2.3)
+      railties (>= 7.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    actionpack (8.1.1)
+      actionview (= 8.1.1)
+      activesupport (= 8.1.1)
+      nokogiri (>= 1.8.5)
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+      useragent (~> 0.16)
+    actionview (8.1.1)
+      activesupport (= 8.1.1)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activesupport (8.1.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     ast (2.4.3)
-    date (3.5.0)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
+    builder (3.3.0)
+    concurrent-ruby (1.3.5)
+    connection_pool (3.0.2)
+    crass (1.0.6)
+    date (3.5.1)
+    difftastic (0.7.0)
+      pretty_please
+    difftastic (0.7.0-arm64-darwin)
+      pretty_please
+    difftastic (0.7.0-x86_64-darwin)
+      pretty_please
+    difftastic (0.7.0-x86_64-linux)
+      pretty_please
+    dispersion (0.2.0)
+      prism
+    drb (2.2.3)
     erb (6.0.0)
+    erubi (1.13.1)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
     io-console (0.8.1)
     irb (1.15.3)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.17.1)
+    json (2.18.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    logger (1.7.0)
+    loofah (2.24.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
     minitest (5.26.2)
+    minitest-difftastic (0.2.1)
+      difftastic (~> 0.6)
+    nokogiri (1.18.10-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-musl)
+      racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.10.0)
       ast (~> 2.4.1)
       racc
     phlex (2.3.1)
       zeitwerk (~> 2.7)
+    phlex-rails (2.3.1)
+      phlex (~> 2.3.0)
+      railties (>= 7.1, < 9)
+      zeitwerk (~> 2.7)
     pp (0.6.3)
       prettyprint
+    pretty_please (0.2.0)
+      dispersion (~> 0.2)
     prettyprint (0.2.0)
     prism (1.6.0)
-    psych (5.2.6)
+    psych (5.3.0)
       date
       stringio
     racc (1.8.1)
+    rack (3.2.4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rackup (2.3.1)
+      rack (>= 3)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.2)
+      loofah (~> 2.21)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (8.1.1)
+      actionpack (= 8.1.1)
+      activesupport (= 8.1.1)
+      irb (~> 1.13)
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
+      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
     rdoc (6.17.0)
@@ -64,22 +168,36 @@ GEM
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
     stringio (3.1.9)
+    thor (1.4.0)
     tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
+    uri (1.1.1)
+    useragent (0.16.11)
     zeitwerk (2.7.3)
 
 PLATFORMS
-  arm64-darwin-24
-  ruby
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   bulma-phlex!
   bulma-phlex-rails!
   irb
   minitest (~> 5.16)
+  minitest-difftastic
   rake (~> 13.0)
   rubocop (~> 1.21)
 

--- a/bulma-phlex-rails.gemspec
+++ b/bulma-phlex-rails.gemspec
@@ -18,4 +18,10 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
 
   spec.files = Dir["lib/**/*"]
+
+  spec.add_dependency "actionpack", ">= 7.2"
+  # this is pinned to main in the Gemfile for now
+  # spec.add_dependency "bulma-phlex", ">= 0.7.0"
+  spec.add_dependency "phlex-rails", ">= 2.3"
+  spec.add_dependency "railties", ">= 7.2"
 end

--- a/lib/bulma_phlex/rails.rb
+++ b/lib/bulma_phlex/rails.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+require "action_view"
 require "bulma-phlex"
+require "phlex-rails"
 require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem_extension(BulmaPhlex)


### PR DESCRIPTION
This pins bulma-phlex to main. The released versions of the gem do not have the updated namespace. Once those updates are release, this will be updated. The two changes will need to occur together.

The development and test dependencies are in the Gemfile, not the gemspec. I do not have strong feelings on this, but followed the default Rubocop config.