### PR TITLE
Define namespace prior to zeitwerk

### DIFF
--- a/lib/bulma_phlex/rails.rb
+++ b/lib/bulma_phlex/rails.rb
@@ -5,19 +5,18 @@ require "bulma-phlex"
 require "phlex-rails"
 require "zeitwerk"
 
+module BulmaPhlex
+  # The Rails namespace provides Bulma Phlex components and helpers for integration with Ruby on Rails applications.
+  module Rails
+  end
+end
+
 loader = Zeitwerk::Loader.for_gem_extension(BulmaPhlex)
 loader.collapse("#{__dir__}/rails/components")
 loader.collapse("#{__dir__}/rails/helpers")
 loader.setup
 
 require "bulma_phlex/rails/engine"
-
-module BulmaPhlex
-  # The Rails namespace provides Bulma Phlex components and helpers for integration with Ruby on Rails applications.
-  module Rails
-    # Your code goes here...
-  end
-end
 
 # Rails-specific extensions to BulmaPhlex components
 BulmaPhlex::Card.include(BulmaPhlex::Rails::CardHelper) if defined?(Turbo)


### PR DESCRIPTION
There was an error in applications when including the gem:

```
There was an error while trying to load the gem 'bulma-phlex-rails'. (Bundler::GemRequireError)
Gem Load Error is: uninitialized constant BulmaPhlex::Rails::Engine
```

Defining the namespace before invoking the loader resolved the error.