### PR TITLE
InputOptions model to capture Bulma options 

### DIFF
--- a/lib/bulma_phlex/rails.rb
+++ b/lib/bulma_phlex/rails.rb
@@ -14,6 +14,7 @@ end
 loader = Zeitwerk::Loader.for_gem_extension(BulmaPhlex)
 loader.collapse("#{__dir__}/rails/components")
 loader.collapse("#{__dir__}/rails/helpers")
+loader.collapse("#{__dir__}/rails/models")
 loader.setup
 
 require "bulma_phlex/rails/engine"

--- a/lib/bulma_phlex/rails/models/input_options.rb
+++ b/lib/bulma_phlex/rails/models/input_options.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module BulmaPhlex
+  module Rails
+    # # Input Options
+    #
+    # Provides predicates and access to Bulma input-specific options
+    class InputOptions
+      INPUT_OPTIONS = %i[suppress_label icon_left icon_right column cell].freeze
+      attr_reader :icon_left, :icon_right, :column, :cell
+
+      # Removes the Bulma-specific input options from the given options hash, returning
+      # the cleaned up hash plus an instance of BulmaPhlex::Rails::InputOptions.
+      def self.from_options(options)
+        [options.reject(*INPUT_OPTIONS), new(options.select(*INPUT_OPTIONS))]
+      end
+
+      def initialize(**options)
+        @suppress_label = options.fetch(:suppress_label, false)
+        @icon_left = options.fetch(:icon_left, nil)
+        @icon_right = options.fetch(:icon_right, nil)
+        @column = options.fetch(:column, false)
+        @cell = options.fetch(:cell, false)
+      end
+
+      def suppress_label?
+        !!@suppress_label
+      end
+
+      def column?
+        !!@column
+      end
+
+      def cell?
+        !!@cell
+      end
+
+      def icon_left?
+        @icon_left.present?
+      end
+
+      def icon_right?
+        @icon_right.present?
+      end
+
+      def icon_control_classes
+        { "has-icons-left": icon_left?, "has-icons-right": icon_right? }
+      end
+    end
+  end
+end

--- a/test/models/input_options_test.rb
+++ b/test/models/input_options_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module BulmaPhlex
+  module Rails
+    class InputOptionsTest < ActiveSupport::TestCase
+      def test_defaults
+        options = InputOptions.new
+        refute_predicate options, :suppress_label?
+        refute_predicate options, :column?
+        refute_predicate options, :cell?
+        refute_predicate options, :icon_left?
+        refute_predicate options, :icon_right?
+      end
+
+      def test_when_suppress_label_is_true
+        options = InputOptions.new(suppress_label: true)
+        assert_predicate options, :suppress_label?
+      end
+
+      def test_when_column_is_true
+        options = InputOptions.new(column: true)
+        assert_predicate options, :column?
+      end
+
+      def test_when_cell_is_true
+        options = InputOptions.new(cell: true)
+        assert_predicate options, :cell?
+      end
+
+      def test_when_icon_left_is_specified
+        options = InputOptions.new(icon_left: "icon-class")
+        assert_predicate options, :icon_left?
+        refute_predicate options, :icon_right?
+        assert_equal({ "has-icons-left": true, "has-icons-right": false }, options.icon_control_classes)
+      end
+
+      def test_when_icon_right_is_specified
+        options = InputOptions.new(icon_right: "icon-class")
+        assert_predicate options, :icon_right?
+        refute_predicate options, :icon_left?
+        assert_equal({ "has-icons-left": false, "has-icons-right": true }, options.icon_control_classes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will remove the bulma-specific options out of the options hash and provide them back with easy accessors including predicate methods.