### PR TITLE
Form Builder: Textarea

### DIFF
--- a/lib/bulma_phlex/rails/form_builder.rb
+++ b/lib/bulma_phlex/rails/form_builder.rb
@@ -30,6 +30,9 @@ module BulmaPhlex
       def number_field(method, **options) = wrap_field(method, options) { |m, opts| super(m, opts) }
       def range_field(method, **options) = wrap_field(method, options) { |m, opts| super(m, opts) }
 
+      def textarea(method, **options) = wrap_field(method, options, add_class: "textarea") { |m, opts| super(m, opts) }
+      alias text_area textarea
+
       def select(method, choices = nil, options = {}, html_options = {}, &)
         wrap_select_field(method, html_options) do |m, html_opts|
           super(m, choices, options, html_opts, &)

--- a/test/form_builder_test.rb
+++ b/test/form_builder_test.rb
@@ -223,6 +223,21 @@ module BulmaPhlex
       end
     end
 
+    class FormBuilderTextareaTest < FormBuilderTestBase
+      def test_textarea
+        html = @form.textarea(:description, placeholder: "Enter description", rows: 10)
+
+        assert_html_equal <<~HTML, html
+          <div class = "field">
+            <label class="label" for="test_model_description">Description</label>
+            <div class="control">
+              <textarea placeholder="Enter description" rows="10" class="textarea" name="test_model[description]" id="test_model_description" />
+            </div>
+          </div>
+        HTML
+      end
+    end
+
     class FormBuilderColumnsTest < FormBuilderTestBase
       def test_columns_wraps_fields_in_columns_div
         html = @form.columns do


### PR DESCRIPTION
Add support for `textarea` (and `text_area`) to Form Builder.