### PR TITLE
Extract help option for Form Field

### DIFF
--- a/lib/bulma_phlex/rails/form_builder.rb
+++ b/lib/bulma_phlex/rails/form_builder.rb
@@ -104,7 +104,7 @@ module BulmaPhlex
         options = options.dup
         options[:class] = Array.wrap(options[:class]) << add_class if add_class
 
-        form_field_options = options.extract!(:icon_left, :icon_right, :column, :grid)
+        form_field_options = options.extract!(:help, :icon_left, :icon_right, :column, :grid)
                                     .with_defaults(column: @columns_flag, grid: @grid_flag)
 
         form_field = FormField.new(**form_field_options) do |f|

--- a/test/form_builder_test.rb
+++ b/test/form_builder_test.rb
@@ -155,6 +155,20 @@ module BulmaPhlex
         assert_match(/placeholder="Enter name"/, html)
         assert_match(/class="is-large input"/, html)
       end
+
+      def test_field_with_help
+        html = @form.text_field(:name, help: "This is your full name")
+
+        assert_html_equal <<~HTML, html
+          <div class = "field">
+            <label class="label" for="test_model_name">Name</label>
+            <div class="control">
+              <input class="input" type="text" value="John Doe" name="test_model[name]" id="test_model_name" />
+            </div>
+            <p class="help">This is your full name</p>
+          </div>
+        HTML
+      end
     end
 
     class FormBuilderInputIconTest < FormBuilderTestBase


### PR DESCRIPTION
The help option was not being extracted into the bulma options, and thus not generating the element.