### PR TITLE
Form Builder: Checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,8 @@
 
 Build Rails applications with the power of Phlex and the elegance of Bulma CSS framework. Use Bulma components and a Rails form builder to create clean, responsive applications.
 
-> [!IMPORTANT]
-> The Form Builder is still under development. The documentation below describes the planned functionality. See the issues list for progress.
->
-> The BulmaPhlex components, with the Rails extensions as well as the related Stimulus controllers, are available now.
 
-
-## Form Builder–Coming Soon!
+## Form Builder
 
 The custom form builder that simplifies the process of creating forms with Bulma styles. It overrides the form helpers to generate Bulma-compatible HTML.
 
@@ -33,34 +28,16 @@ It generates the following HTML (assuming a form object for a Project model):
 </div>
 ```
 
-The following form helpers are supported:
+All of the standard Rails form helpers are supported. Under the hood the form builder still uses Rails form helpers, so all standard options are supported as well and you get the full power of Rails forms.
 
-- text_field
-- password_field
-- telephone_field
-- date_field
-- time_field
-- datetime_field
-- datetime_local_field
-- week_field
-- month_field
-- url_field
-- email_field
-- number_field
-- search_field
-- color_field
-- range_field
-- select
-- collection_select
+> [!NOTE]
+> The following form helpers are still under construction:
+>
+> - collection_checkboxes
+> - collection_radio_buttons
+> - file_field
+> - radio_button
 
-The following form helpers are still under construction:
-
-- checkbox
-- checkbox_display
-- file_field
-- text_area
-- textarea
-- submit_tag
 
 In addition to the standard options, the following options are supported for inputs:
 
@@ -70,14 +47,22 @@ In addition to the standard options, the following options are supported for inp
 - column: Specify Bulma column classes for responsive layouts
 - cell: Specify Bulma grid cell classes for responsive layouts
 
-For example, want your amount input to include a dollar sign icon?
+For example, want your name field to include a user icon?
 
 ```ruby
-form.text_field :amount, icon_left: "dollar-sign"
+form.text_field :name, icon_left: "fas fa-user"
 ```
 
-> [!NOTE]
-> Under the hood the form builder still uses Rails form helpers, so all standard options are supported as well and you get the full power of Rails forms.
+#### Checkbox
+
+The checkbox method on the Form Builder generates a Bulma-styled checkbox input. If the label needs to be HTML instead of plain text, pass a block to the method.
+
+```ruby
+form.checkbox :terms_of_service do
+  span { "I agree to the " }
+  a(href: '/terms') { 'the Terms' }
+end
+```
 
 ### Columns and Grids
 
@@ -151,7 +136,10 @@ end
 
 All of the power of Bulma columns and grids are at your fingertips with an easy-to-use, Rails-friendly API.
 
-### Form Addons and Groups
+### Form Addons and Groups--Coming Soon!
+
+> [!IMPORTANT]
+> This feature has not yet been implemented.
 
 Bulma can [attach inputs, buttons, and dropdowns](https://bulma.io/documentation/form/general/#form-addons) or [group controls together](https://bulma.io/documentation/form/general/#form-group). Helper methods make those easy, too.
 

--- a/lib/bulma_phlex/rails/components/checkbox.rb
+++ b/lib/bulma_phlex/rails/components/checkbox.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module BulmaPhlex
+  module Rails
+    # # Checkbox Component
+    #
+    # This component renders a Bulma-styled checkbox within a form. It integrates with Rails' form builder
+    # to ensure proper labeling and value handling.
+    #
+    # The label can be generated automatically based on the attribute name or customized using a block.
+    #
+    # Example usage:
+    #
+    # ```ruby
+    # form_with model: @user do |f|
+    #   f.checkbox :subscribe_newsletter
+    #   f.checkbox :terms_of_service do
+    #     span { "I agree to " }
+    #     a(href: "/terms") { "the terms and conditions" }
+    #   end
+    # end
+    # ```
+    class Checkbox < BulmaPhlex::Base
+      def initialize(form_builder, method, options, delivered, label_block)
+        @form_builder = form_builder
+        @method = method
+        @options = options.dup
+        @delivered = delivered
+        @label_block = label_block
+
+        @options[:class] = Array.wrap(@options[:class]) << "mr-2"
+        @form_field_options = @options.extract!(:column, :grid)
+                                      .with_defaults(column: @form_builder.columns_flag,
+                                                     grid: @form_builder.grid_flag)
+      end
+
+      def view_template
+        render FormField.new(**@form_field_options) do |f|
+          f.control do
+            @form_builder.label(@method, nil, class: "checkbox", skip_label_class: true) do |label_builder|
+              raw @delivered.call(@options)
+              render_label(label_builder)
+            end
+          end
+        end
+      end
+
+      private
+
+      def render_label(label_builder)
+        output = @label_block ? @label_block.call(label_builder) : label_builder.to_s
+
+        # ActiveSupport::SafeBuffer is html safe, strings are not
+        if output.html_safe?
+          raw output
+        else
+          plain output
+        end
+      end
+    end
+  end
+end

--- a/lib/bulma_phlex/rails/form_builder.rb
+++ b/lib/bulma_phlex/rails/form_builder.rb
@@ -13,6 +13,8 @@ module BulmaPhlex
     # - `column`: If true, the input will be wrapped in a Bulma column (only within a `columns` block).
     # - `grid`: If true, the input will be wrapped in a Bulma grid cell (only within a `grid` block).
     class FormBuilder < ActionView::Helpers::FormBuilder
+      attr_reader :columns_flag, :grid_flag
+
       def text_field(method, **options) = wrap_field(method, options) { |m, opts| super(m, opts) }
       def password_field(method, **options) = wrap_field(method, options) { |m, opts| super(m, opts) }
       def color_field(method, **options) = wrap_field(method, options) { |m, opts| super(m, opts) }
@@ -32,6 +34,12 @@ module BulmaPhlex
 
       def textarea(method, **options) = wrap_field(method, options, add_class: "textarea") { |m, opts| super(m, opts) }
       alias text_area textarea
+
+      def checkbox(method, options = {}, checked_value = "1", unchecked_value = "0", &label_block)
+        delivered = ->(opts) { super(method, opts, checked_value, unchecked_value) }
+        Checkbox.new(self, method, options, delivered, label_block).render_in(@template)
+      end
+      alias check_box checkbox
 
       # Override label to add Bulma's `label` class by default. Add `:skip_label_class` option
       # to skip adding the class.

--- a/test/components/checkbox_test.rb
+++ b/test/components/checkbox_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module BulmaPhlex
+  module Rails
+    class CheckboxTest < ComponentTestCase
+      # Create a simple model for testing
+      class TestModel
+        include ActiveModel::Model
+
+        attr_accessor :active
+
+        def self.model_name
+          ActiveModel::Name.new(self, nil, "TestModel")
+        end
+      end
+
+      def setup
+        super
+        @model = TestModel.new(active: true)
+        @form_builder = BulmaPhlex::Rails::FormBuilder.new(:test_model, @model, view_context, {})
+      end
+
+      def test_checkbox
+        html = @form_builder.checkbox(:active)
+
+        assert_html_equal <<~HTML, html
+          <div class="field">
+            <div class="control">
+              <label class="checkbox" for="test_model_active">
+                <input name="test_model[active]" type="hidden" value="0" autocomplete="off">
+                <input type="checkbox" name="test_model[active]" id="test_model_active" value="1" checked="checked" class="mr-2" />
+                Active
+              </label>
+            </div>
+          </div>
+        HTML
+      end
+
+      def test_checkbox_with_label_block_that_returns_string
+        html = @form_builder.checkbox(:active) do
+          "I agree to the terms and conditions"
+        end
+
+        assert_html_equal <<~HTML, html
+          <div class="field">
+            <div class="control">
+              <label class="checkbox" for="test_model_active">
+                <input name="test_model[active]" type="hidden" value="0" autocomplete="off">
+                <input type="checkbox" name="test_model[active]" id="test_model_active" value="1" checked="checked" class="mr-2" />
+                I agree to the terms and conditions
+              </label>
+            </div>
+          </div>
+        HTML
+      end
+
+      def test_checkbox_with_label_block_that_returns_html
+        html = @form_builder.checkbox(:active) do
+          view_context.content_tag(:span) { "I agree to the " } +
+            view_context.link_to("terms and conditions", "/terms")
+        end
+
+        assert_html_equal <<~HTML, html
+          <div class="field">
+            <div class="control">
+              <label class="checkbox" for="test_model_active">
+                <input name="test_model[active]" type="hidden" value="0" autocomplete="off">
+                <input type="checkbox" name="test_model[active]" id="test_model_active" value="1" checked="checked" class="mr-2" />
+                <span>I agree to the </span>
+                <a href="/terms">terms and conditions</a>
+              </label>
+            </div>
+          </div>
+        HTML
+      end
+
+      def test_in_columns
+        html = @form_builder.columns do
+          @form_builder.checkbox(:active)
+        end
+
+        assert_match(/<div class="field column">/, html)
+      end
+
+      def test_in_grid
+        html = @form_builder.grid do
+          @form_builder.checkbox(:active)
+        end
+
+        assert_match(/<div class="field cell">/, html)
+      end
+    end
+  end
+end

--- a/test/form_builder_test.rb
+++ b/test/form_builder_test.rb
@@ -11,7 +11,7 @@ module BulmaPhlex
       class TestModel
         include ActiveModel::Model
 
-        attr_accessor :name, :email, :password, :description
+        attr_accessor :name, :email, :password, :description, :active
 
         def self.model_name
           ActiveModel::Name.new(self, nil, "TestModel")
@@ -19,7 +19,7 @@ module BulmaPhlex
       end
 
       def setup
-        @model = TestModel.new(name: "John Doe", email: "john@example.com")
+        @model = TestModel.new(name: "John Doe", email: "john@example.com", active: true)
         @form = FormBuilder.new(
           :test_model,
           @model,
@@ -266,6 +266,25 @@ module BulmaPhlex
 
         assert_html_equal <<~HTML, html
           <label for="test_model_name">Full Name</label>
+        HTML
+      end
+    end
+
+    class FormBuilderCheckboxTest < FormBuilderTestBase
+      def test_checkbox
+        html = @form.check_box(:active)
+
+        # it shows translation missing since we have no i18n setup in the test
+        assert_html_equal <<~HTML, html
+          <div class="field">
+            <div class="control">
+              <label class="checkbox" for="test_model_active">
+                <input name="test_model[active]" type="hidden" value="0" autocomplete="off">
+                <input class="mr-2" type="checkbox" value="1" checked="checked" name="test_model[active]" id="test_model_active">
+                Active
+              </label>
+            </div>
+          </div>
         HTML
       end
     end


### PR DESCRIPTION
This overrides the `checkbox` method (along with the `check_box` alias) to generate Bulma-friendly HTML.

Since the majority of the form builder methods have been completed, this updates the README so that it calls out what has __not been completed__.