### PR TITLE
Relax required ruby version to 3.2.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "3.4.7"
+          - "3.2"
+          - "3.3"
+          - "3.4"
+          - "4.0"
 
     steps:
       - uses: actions/checkout@v6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.4
+  TargetRubyVersion: 3.2
   NewCops: enable
 
 Lint/MissingSuper:

--- a/bulma-phlex-rails.gemspec
+++ b/bulma-phlex-rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   SUMMARY
   spec.homepage = "https://github.com/RockSolt/bulma-phlex-rails"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.4"
+  spec.required_ruby_version = ">= 3.2.10"
 
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
Update the CI test matrix to include 3.2, 3.3, 3.4, and 4.0.