### PR TITLE
Bump minimum required Ruby to 3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "3.2"
           - "3.3"
           - "3.4"
           - "4.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
   NewCops: enable
   SuggestExtensions:
     rubocop-rake: false
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
 
 Lint/MissingSuper:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -69,9 +69,8 @@ gem install bulma-phlex-rails
 
 This gem requires:
 
-- Ruby 3.2.10 or higher
+- Ruby 3.3 or higher
 - Rails 7.2 or higher
-- Phlex Rails 2.4 or higher
 - Bulma CSS (which you'll need to include in your application)
 
 ### Required Setup

--- a/bulma-phlex-rails.gemspec
+++ b/bulma-phlex-rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   SUMMARY
   spec.homepage = "https://github.com/RockSolt/bulma-phlex-rails"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.10"
+  spec.required_ruby_version = ">= 3.3"
 
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
Ruby 3.2 is EOL as of March 31, 2026. This bumps the minimum required ruby version to 3.3 and removes the 3.2 testing.