### PR TITLE
Release 0.8.0: Bump Min Required Ruby to 3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    bulma-phlex-rails (0.7.1)
+    bulma-phlex-rails (0.8.0)
       actionpack (>= 7.2)
-      bulma-phlex (>= 0.14.0)
+      bulma-phlex (>= 0.15.0)
       phlex-rails (>= 2.4)
       railties (>= 7.2)
 
@@ -49,7 +49,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.1)
     builder (3.3.0)
-    bulma-phlex (0.14.0)
+    bulma-phlex (0.15.0)
       phlex (>= 2.4.1)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)

--- a/bulma-phlex-rails.gemspec
+++ b/bulma-phlex-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*", "app/**/*", "config/importmap.rb"]
 
   spec.add_dependency "actionpack", ">= 7.2"
-  spec.add_dependency "bulma-phlex", ">= 0.14.0"
+  spec.add_dependency "bulma-phlex", ">= 0.15.0"
   spec.add_dependency "phlex-rails", ">= 2.4"
   spec.add_dependency "railties", ">= 7.2"
 end

--- a/lib/bulma_phlex/rails/version.rb
+++ b/lib/bulma_phlex/rails/version.rb
@@ -2,6 +2,6 @@
 
 module BulmaPhlex
   module Rails
-    VERSION = "0.7.1"
+    VERSION = "0.8.0"
   end
 end


### PR DESCRIPTION
This release bumps the minimum required Ruby to 3.3. It also bumps Bulma Phlex to 0.15.