### PR TITLE
Support HTML attributes on Columns and Grids

### DIFF
--- a/lib/bulma_phlex/rails/form_builder.rb
+++ b/lib/bulma_phlex/rails/form_builder.rb
@@ -182,16 +182,20 @@ module BulmaPhlex
       #   to set responsive gap sizes.
       # - `centered`: (Boolean, optional) If true, centers the columns.
       # - `vcentered`: (Boolean, optional) If true, vertically centers the columns.
-      def columns(minimum_breakpoint: nil,
+      #
+      # Any additional HTML attributes passed to the `columns` method will be applied to the outer columns container.
+      def columns(minimum_breakpoint: nil, # rubocop:disable Metrics/ParameterLists
                   multiline: false,
                   gap: nil,
                   centered: false,
-                  vcentered: false, &)
+                  vcentered: false,
+                  **html_attributes,
+                  &)
         @columns_flag = true
         columns = @template.capture(&)
         @columns_flag = false
 
-        BulmaPhlex::Columns.new(minimum_breakpoint:, multiline:, gap:, centered:, vcentered:) do
+        BulmaPhlex::Columns.new(minimum_breakpoint:, multiline:, gap:, centered:, vcentered:, **html_attributes) do
           @template.concat(columns)
         end.render_in(@template)
       end
@@ -208,18 +212,22 @@ module BulmaPhlex
       # - `gap`: (optional) Sets the gap size between grid items from 1-8 with 0.5 increments.
       # - `column_gap`: (optional) Sets the column gap size between grid items from 1-8 with 0.5 increments.
       # - `row_gap`: (optional) Sets the row gap size between grid items from 1-8 with 0.5 increments.
+      #
+      # Any additional HTML attributes passed to the `grid` method will be applied to the outer grid container.
       def grid(fixed_columns: nil, # rubocop:disable Metrics/ParameterLists
                auto_count: false,
                minimum_column_width: nil,
                gap: nil,
                column_gap: nil,
                row_gap: nil,
+               **html_attributes,
                &)
         @grid_flag = true
         cells = @template.capture(&)
         @grid_flag = false
 
-        BulmaPhlex::Grid.new(fixed_columns:, auto_count:, minimum_column_width:, gap:, column_gap:, row_gap:) do
+        BulmaPhlex::Grid.new(fixed_columns:, auto_count:, minimum_column_width:, gap:, column_gap:, row_gap:,
+                             **html_attributes) do
           @template.concat(cells)
         end.render_in(@template)
       end

--- a/test/form_builder_test.rb
+++ b/test/form_builder_test.rb
@@ -799,6 +799,15 @@ module BulmaPhlex
           </div>
         HTML
       end
+
+      def test_columns_with_html_attributes
+        html = @form.columns(class: "mt-2") do
+          @form.text_field(:name) +
+            @form.email_field(:email, column: "two-thirds")
+        end
+
+        assert_html_includes html, 'class="columns mt-2"'
+      end
     end
 
     class FormBuilderGridTest < FormBuilderTestBase
@@ -850,6 +859,15 @@ module BulmaPhlex
             </div>
           </div>
         HTML
+      end
+
+      def test_grid_with_html_attributes
+        html = @form.grid(class: "mt-2") do
+          @form.text_field(:name) +
+            @form.email_field(:email, grid: "col-span-3")
+        end
+
+        assert_html_includes html, 'class="grid mt-2"'
       end
     end
   end


### PR DESCRIPTION
This enhances the form builder's columns and grids method to enable additional HTML attributes to be specified. The attributes are passed along to the Bulma Phlex component and added to the wrapping div.